### PR TITLE
scalafmt lineEndings

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,4 @@
 version = 2.7.5
 
-preset=IntelliJ
+preset = IntelliJ
+lineEndings = preserve


### PR DESCRIPTION
Added lineEndings in `.scalafmt.conf` to preserve the LF or CRLF formatting